### PR TITLE
Add Node Grab Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # node-grab
+
+Chrome extension that lets you pick any DOM element on a page, hide everything else, resize the element, and capture a screenshot of it.
+
+## Usage
+
+1. Open Chrome and navigate to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select this folder.
+4. Click the Node Grab icon, hover over the page to highlight an element and click to select it.
+5. Adjust the size using the resize handle or input boxes, then click **Capture** to download the image.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,19 @@
+chrome.action.onClicked.addListener(async (tab) => {
+  try {
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      files: ['content.js']
+    });
+  } catch (e) {
+    console.error('Injection failed', e);
+  }
+});
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.action === 'capture') {
+    chrome.tabs.captureVisibleTab(sender.tab.windowId, { format: 'png' }, (dataUrl) => {
+      sendResponse({ image: dataUrl });
+    });
+    return true; // keep message channel open for async response
+  }
+});

--- a/content.js
+++ b/content.js
@@ -1,0 +1,91 @@
+(function() {
+  if (window.__nodeGrabInjected) return;
+  window.__nodeGrabInjected = true;
+
+  const style = document.createElement('style');
+  style.textContent = `
+    .node-grab-hover { outline: 2px solid #3f51b5 !important; cursor: crosshair !important; }
+  `;
+  document.head.appendChild(style);
+
+  function startSelection() {
+    let current;
+
+    function mousemove(e) {
+      if (current) current.classList.remove('node-grab-hover');
+      current = e.target;
+      current.classList.add('node-grab-hover');
+    }
+
+    function clickHandler(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      cleanup();
+      selectElement(e.target);
+    }
+
+    function cleanup() {
+      document.removeEventListener('mousemove', mousemove);
+      document.removeEventListener('click', clickHandler, true);
+      if (current) current.classList.remove('node-grab-hover');
+    }
+
+    document.addEventListener('mousemove', mousemove);
+    document.addEventListener('click', clickHandler, true);
+  }
+
+  function selectElement(elem) {
+    // hide all elements not related to selection
+    const all = document.body.getElementsByTagName('*');
+    for (const el of all) {
+      if (!el.contains(elem) && el !== elem && !elem.contains(el)) {
+        el.dataset.ngDisplay = el.style.display;
+        el.style.display = 'none';
+      }
+    }
+
+    const rect = elem.getBoundingClientRect();
+
+    const wrapper = document.createElement('div');
+    wrapper.style.cssText = `position:fixed; top:${rect.top}px; left:${rect.left}px; width:${rect.width}px; height:${rect.height}px; resize:both; overflow:auto; border:2px dashed #3f51b5; background:white; z-index:2147483647;`;
+    document.body.appendChild(wrapper);
+    wrapper.appendChild(elem);
+
+    const panel = document.createElement('div');
+    panel.style.cssText = 'position:fixed; top:10px; right:10px; z-index:2147483647; background:white; padding:8px; border:1px solid #ccc; font-family:sans-serif;';
+    panel.innerHTML = `Width: <input type="number" id="ngWidth" value="${Math.round(rect.width)}" style="width:60px"> px
+    Height: <input type="number" id="ngHeight" value="${Math.round(rect.height)}" style="width:60px"> px
+    <button id="ngApply">Apply</button>
+    <button id="ngCapture">Capture</button>`;
+    document.body.appendChild(panel);
+
+    document.getElementById('ngApply').onclick = () => {
+      const w = parseInt(document.getElementById('ngWidth').value, 10);
+      const h = parseInt(document.getElementById('ngHeight').value, 10);
+      if (!isNaN(w)) wrapper.style.width = w + 'px';
+      if (!isNaN(h)) wrapper.style.height = h + 'px';
+    };
+
+    document.getElementById('ngCapture').onclick = () => {
+      const r = wrapper.getBoundingClientRect();
+      chrome.runtime.sendMessage({ action: 'capture' }, ({ image }) => {
+        const img = new Image();
+        img.onload = function() {
+          const canvas = document.createElement('canvas');
+          canvas.width = r.width;
+          canvas.height = r.height;
+          const ctx = canvas.getContext('2d');
+          ctx.drawImage(img, r.left, r.top, r.width, r.height, 0, 0, r.width, r.height);
+          const url = canvas.toDataURL('image/png');
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'capture.png';
+          a.click();
+        };
+        img.src = image;
+      });
+    };
+  }
+
+  startSelection();
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 3,
+  "name": "Node Grab",
+  "version": "1.0",
+  "description": "Select a DOM node, isolate it, resize and capture.",
+  "permissions": ["activeTab", "scripting", "tabs"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_title": "Node Grab"
+  }
+}


### PR DESCRIPTION
## Summary
- implement Chrome extension to pick a DOM element, isolate it, resize and capture screenshot
- document usage in README
- remove bundled icon PNG assets and related manifest references

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3c7c5b608328924c61a0ed33b6be