### PR TITLE
Hide selection border during capture

### DIFF
--- a/content.js
+++ b/content.js
@@ -67,8 +67,11 @@
     };
 
     document.getElementById('ngCapture').onclick = () => {
+      const originalBorder = wrapper.style.border;
+      wrapper.style.border = 'none';
       const r = wrapper.getBoundingClientRect();
       chrome.runtime.sendMessage({ action: 'capture' }, ({ image }) => {
+        wrapper.style.border = originalBorder;
         const img = new Image();
         img.onload = function() {
           const canvas = document.createElement('canvas');


### PR DESCRIPTION
## Summary
- Temporarily remove the selection wrapper's border before taking a screenshot to keep captures clean
- Restore the wrapper's original border style after the capture completes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac42df22008328a3095517f72fa587