### PR TITLE
Hide selection border during capture

### DIFF
--- a/content.js
+++ b/content.js
@@ -67,22 +67,27 @@
     };
 
     document.getElementById('ngCapture').onclick = () => {
-      const r = wrapper.getBoundingClientRect();
-      chrome.runtime.sendMessage({ action: 'capture' }, ({ image }) => {
-        const img = new Image();
-        img.onload = function() {
-          const canvas = document.createElement('canvas');
-          canvas.width = r.width;
-          canvas.height = r.height;
-          const ctx = canvas.getContext('2d');
-          ctx.drawImage(img, r.left, r.top, r.width, r.height, 0, 0, r.width, r.height);
-          const url = canvas.toDataURL('image/png');
-          const a = document.createElement('a');
-          a.href = url;
-          a.download = 'capture.png';
-          a.click();
-        };
-        img.src = image;
+      const originalBorder = wrapper.style.border;
+      wrapper.style.border = 'none';
+      requestAnimationFrame(() => {
+        const r = wrapper.getBoundingClientRect();
+        chrome.runtime.sendMessage({ action: 'capture' }, ({ image }) => {
+          wrapper.style.border = originalBorder;
+          const img = new Image();
+          img.onload = function() {
+            const canvas = document.createElement('canvas');
+            canvas.width = r.width;
+            canvas.height = r.height;
+            const ctx = canvas.getContext('2d');
+            ctx.drawImage(img, r.left, r.top, r.width, r.height, 0, 0, r.width, r.height);
+            const url = canvas.toDataURL('image/png');
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'capture.png';
+            a.click();
+          };
+          img.src = image;
+        });
       });
     };
   }


### PR DESCRIPTION
## Summary
- Temporarily remove the selection wrapper's border and wait for the next animation frame before capturing to keep screenshots clean
- Restore the wrapper's original border style after the capture completes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac42df22008328a3095517f72fa587