### PR TITLE
Resize window before capturing

### DIFF
--- a/background.js
+++ b/background.js
@@ -9,11 +9,24 @@ chrome.action.onClicked.addListener(async (tab) => {
   }
 });
 
-chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-  if (msg.action === 'capture') {
-    chrome.tabs.captureVisibleTab(sender.tab.windowId, { format: 'png' }, (dataUrl) => {
-      sendResponse({ image: dataUrl });
-    });
-    return true; // keep message channel open for async response
-  }
-});
+  chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+    if (msg.action === 'capture') {
+      const { width, height, devicePixelRatio } = msg;
+      const windowId = sender.tab.windowId;
+      chrome.windows.get(windowId, { populate: false }, (win) => {
+        const originalWidth = win.width;
+        const originalHeight = win.height;
+        const scale = devicePixelRatio || 1;
+        const targetWidth = Math.round(width * scale);
+        const targetHeight = Math.round(height * scale);
+        chrome.windows.update(windowId, { width: targetWidth, height: targetHeight }, () => {
+          chrome.tabs.captureVisibleTab(windowId, { format: 'png' }, (dataUrl) => {
+            chrome.windows.update(windowId, { width: originalWidth, height: originalHeight }, () => {
+              sendResponse({ image: dataUrl });
+            });
+          });
+        });
+      });
+      return true; // keep message channel open for async response
+    }
+  });

--- a/content.js
+++ b/content.js
@@ -94,7 +94,12 @@
         const top = (r.top + window.scrollY) * scale;
         const width = r.width * scale;
         const height = r.height * scale;
-        chrome.runtime.sendMessage({ action: 'capture' }, ({ image }) => {
+        chrome.runtime.sendMessage({
+          action: 'capture',
+          width: r.width,
+          height: r.height,
+          devicePixelRatio: scale
+        }, ({ image }) => {
           wrapper.style.border = originalBorder;
           const img = new Image();
           img.onload = function() {

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Node Grab",
   "version": "1.0",
   "description": "Select a DOM node, isolate it, resize and capture.",
-  "permissions": ["activeTab", "scripting", "tabs"],
+    "permissions": ["activeTab", "scripting", "tabs", "windows"],
   "background": {
     "service_worker": "background.js"
   },


### PR DESCRIPTION
## Summary
- Include wrapper dimensions and device pixel ratio when requesting a capture
- Temporarily resize the window to match the target element before taking a screenshot and restore afterward
- Add `windows` permission to enable window resizing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4cd0e5048328be10cb5fa5f6d9d8