### PR TITLE
Handle wrapper outline and focus during capture

### DIFF
--- a/content.js
+++ b/content.js
@@ -87,41 +87,46 @@
     document.getElementById('ngCapture').onclick = () => {
       const originalBorder = wrapper.style.border;
       const originalOutline = wrapper.style.outline;
+      const originalBoxShadow = wrapper.style.boxShadow;
       const hadFocus = wrapper.matches(':focus');
       wrapper.style.border = 'none';
       wrapper.style.outline = 'none';
+      wrapper.style.boxShadow = 'none';
       if (hadFocus) wrapper.blur();
       requestAnimationFrame(() => {
-        const r = wrapper.getBoundingClientRect();
-        const scale = window.devicePixelRatio;
-        const left = (r.left + window.scrollX) * scale;
-        const top = (r.top + window.scrollY) * scale;
-        const width = r.width * scale;
-        const height = r.height * scale;
-        chrome.runtime.sendMessage({ action: 'capture' }, (response) => {
-          wrapper.style.border = originalBorder;
-          wrapper.style.outline = originalOutline;
-          if (hadFocus) wrapper.focus();
-          if (!response || chrome.runtime.lastError) {
-            console.error('Capture failed', chrome.runtime.lastError);
-            return;
-          }
-          const img = new Image();
-          img.onload = function() {
-            const canvas = document.createElement('canvas');
-            canvas.width = width;
-            canvas.height = height;
-            const ctx = canvas.getContext('2d');
-            ctx.drawImage(img, left, top, width, height, 0, 0, width, height);
-            const url = canvas.toDataURL('image/png');
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = 'capture.png';
-            document.body.appendChild(a);
-            a.click();
-            a.remove();
-          };
-          img.src = response.image;
+        requestAnimationFrame(() => {
+          const r = wrapper.getBoundingClientRect();
+          const scale = window.devicePixelRatio;
+          const left = (r.left + window.scrollX) * scale;
+          const top = (r.top + window.scrollY) * scale;
+          const width = r.width * scale;
+          const height = r.height * scale;
+          chrome.runtime.sendMessage({ action: 'capture' }, (response) => {
+            wrapper.style.border = originalBorder;
+            wrapper.style.outline = originalOutline;
+            wrapper.style.boxShadow = originalBoxShadow;
+            if (hadFocus) wrapper.focus();
+            if (!response || chrome.runtime.lastError) {
+              console.error('Capture failed', chrome.runtime.lastError);
+              return;
+            }
+            const img = new Image();
+            img.onload = function() {
+              const canvas = document.createElement('canvas');
+              canvas.width = width;
+              canvas.height = height;
+              const ctx = canvas.getContext('2d');
+              ctx.drawImage(img, left, top, width, height, 0, 0, width, height);
+              const url = canvas.toDataURL('image/png');
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = 'capture.png';
+              document.body.appendChild(a);
+              a.click();
+              a.remove();
+            };
+            img.src = response.image;
+          });
         });
       });
     };


### PR DESCRIPTION
## Summary
- Preserve wrapper's outline and focus state during capture
- Hide border and outline before screenshot
- Restore both styles after capture completes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5679abf08328be1b73a33642ae1b