### PR TITLE
Hide capture panel during screenshot

### DIFF
--- a/content.js
+++ b/content.js
@@ -89,10 +89,12 @@
       const originalOutline = wrapper.style.outline;
       const originalBoxShadow = wrapper.style.boxShadow;
       const hadFocus = wrapper.matches(':focus');
+      const originalPanelDisplay = panel.style.display;
       wrapper.style.border = 'none';
       wrapper.style.outline = 'none';
       wrapper.style.boxShadow = 'none';
       if (hadFocus) wrapper.blur();
+      panel.style.display = 'none';
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           const r = wrapper.getBoundingClientRect();
@@ -106,6 +108,7 @@
             wrapper.style.outline = originalOutline;
             wrapper.style.boxShadow = originalBoxShadow;
             if (hadFocus) wrapper.focus();
+            panel.style.display = originalPanelDisplay;
             if (!response || chrome.runtime.lastError) {
               console.error('Capture failed', chrome.runtime.lastError);
               return;


### PR DESCRIPTION
## Summary
- Hide selection panel before screenshot to avoid capturing controls
- Restore panel visibility after image generation

## Testing
- ⚠️ `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5a728244832881ff16f6295e91ff