### PR TITLE
Hide resize handle during capture

### DIFF
--- a/content.js
+++ b/content.js
@@ -115,12 +115,14 @@
       const originalOutline = wrapper.style.outline;
       const originalBoxShadow = wrapper.style.boxShadow;
       const originalOverflow = wrapper.style.overflow;
+      const originalResize = wrapper.style.resize;
       const hadFocus = wrapper.matches(':focus');
       const originalPanelDisplay = panel.style.display;
       wrapper.style.border = 'none';
       wrapper.style.outline = 'none';
       wrapper.style.boxShadow = 'none';
       wrapper.style.overflow = 'hidden';
+      wrapper.style.resize = 'none';
       if (hadFocus) wrapper.blur();
       panel.style.display = 'none';
       requestAnimationFrame(() => {
@@ -231,6 +233,7 @@
           wrapper.style.outline = originalOutline;
           wrapper.style.boxShadow = originalBoxShadow;
           wrapper.style.overflow = originalOverflow;
+          wrapper.style.resize = originalResize;
           if (hadFocus) wrapper.focus();
           panel.style.display = originalPanelDisplay;
           restoreOverflow();


### PR DESCRIPTION
## Summary
- Remove resize handles from selected element during capture
- Restore resize property after screenshot

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68ac6a9d8a688328b3bb62d65ec74fdd